### PR TITLE
fix: use the proper constant

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_audio.h>
 
-#define PI2 6.28318530718
+#define TAU 6.28318530718
 
 float time = 0;
 float freq = 440;
@@ -20,8 +20,8 @@ void callback(void* userdata, Uint8* stream, int len)
     len /= sizeof(*snd);
     for(int i = 0; i < len; i++) {
         snd[i] = 32000 * sin(time);
-        time += freq * PI2 / 48000.0;
-        if(time >= PI2) time -= PI2;
+        time += freq * TAU / 48000.0;
+        if(time >= TAU) time -= TAU;
     }
 }
 


### PR DESCRIPTION
`TAU` is a better description of the value instead of `PI2`, which can be mistaken as "the 2nd Pi".
Yeah, I am bike-shedding, but doing it well.

But of course Pi is the better constant, Tau is only better in the current context.
All hail Pi:
```
 π = 3.1415926535897932
38462643383279502884197
16939937510582097494459
2307...

Thats all from memory 😎
67 digits of the best mathematical constant
```